### PR TITLE
accounting for yarn install for inconsistent test directories

### DIFF
--- a/mdct-setup.sh
+++ b/mdct-setup.sh
@@ -405,6 +405,30 @@ for url in "${repo_urls[@]}"; do
     # Run yarn in /services/app-api/ directory
     echo "Running yarn in /services/uploads/ directory..."
     (cd services/uploads/ && yarn)
+
+    # Check if tests/cypress node_modules directory exists
+    if [ -d "tests/cypress/node_modules" ]; then
+        echo "tests/cypress/node_modules directory found. Removing its contents..."
+        rm -rf tests/cypress/node_modules
+    fi
+
+    # If the tets live in tests/cypress ... run yarn there
+    if [ -d "tests/cypress" ]; then
+        echo "running yarn in the tests/cypress folder...."
+        (cd tests/cypress && yarn)
+    fi
+
+    # Check if tests node_modules directory exists
+    if [ -d "tests/node_modules" ]; then
+        echo "tests/node_modules directory found. Removing its contents..."
+        rm -rf tests/node_modules
+    fi
+
+    # If the tets live in tests ... run yarn there
+    if [ -f "tests/package.json" ]; then
+        echo "running yarn in the tests folder...."
+        (cd tests && yarn)
+    fi
     
     # Check if yarn was successful
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
### Description
because the package.json lives in a different directory in mfp than our other products this pr accounts for this so that we can clear out the node_modules directory for tests in all our products as well as do a yarn install


### Related ticket(s)
na

---
### How to test
run script -> ./run update-env in any product -> yarn test 
this should yield working tests with no manual intervention 


### Notes



---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---
