### PR TITLE
Fixing logic for java install to support intel based macs 

### DIFF
--- a/mdct-setup.sh
+++ b/mdct-setup.sh
@@ -236,7 +236,7 @@ if ! which pre-commit > /dev/null ; then
 fi
 
 # Install java with brew 
-if [[ ! $(which java) =~ "homebrew" ]] ; then
+if [[ ! $(which java) =~ "$(brew --prefix)/opt/openjdk" ]] ; then
   echo "brew installing java"
 	brew install java
   # Get the directory where java is installed
@@ -248,7 +248,7 @@ if [[ ! $(which java) =~ "homebrew" ]] ; then
   # echo "Java installed successfully and added to PATH."
   source $shellprofile
   # Check if java is installed and add it to PATH if necessary
-  if [[ ! $(which java) =~ "homebrew" ]] ; then
+  if [[ ! $(which java) =~ "$(brew --prefix)/opt/openjdk" ]] ; then
       echo "Java installation failed." && exit 1
   fi
 fi


### PR DESCRIPTION
### Description
the java install logic worked for m series macs that installed homebew at a certain path but did not support intel based macs. this fixes that and uses the same logic for both intel and m series macs.


### Related ticket(s)

---
### How to test
uninstall java (brew uninstall java, rm any references to path in shell profile files, relaunch terminal and echo $PATH to confirm there are no java references)
re-run workspace setup 
relaunch terminal and which java or java --version should work 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---
