### PR TITLE
Adding support for hcbs and core to workspace setup

### DIFF
--- a/mdct-setup.sh
+++ b/mdct-setup.sh
@@ -1,7 +1,7 @@
 set -e
 
 # Script version
-SCRIPT_VERSION="1.0.0"
+SCRIPT_VERSION="1.0.1"
 
 # Define the clone directory and version file
 clone_dir="$HOME/Projects"
@@ -14,7 +14,9 @@ repo_urls=(
     "https://github.com/Enterprise-CMCS/macpro-mdct-qmr.git"
     "https://github.com/Enterprise-CMCS/macpro-mdct-mcr.git"
     "https://github.com/Enterprise-CMCS/macpro-mdct-mfp.git"
+    "https://github.com/Enterprise-CMCS/macpro-mdct-hcbs.git"
     "https://github.com/Enterprise-CMCS/macpro-mdct-tools.git"
+    "https://github.com/Enterprise-CMCS/macpro-mdct-core.git"
 )
 
 # Check that user is using MacOS


### PR DESCRIPTION
### Description
adding the ability to pull and run through hcbs and core repos similar to the other apps and making a patch update 

### Related ticket(s)
n/a

---
### How to test
testing workspace setup is kind of tricky ... the script checks to make sure you're on main or master before you can run. what i typically do is 
cd ~/
rm mdct-setup.sh
cp ~/Projects/macpro-mdct-tools/mdct-setup.sh .
cd ~/Projects/macpro-mdct-tools
git checkout main
cd
sh mdct-setup.sh 

theres probably better ways to do this but this is what i do for now 


### Notes



---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---
