### PR TITLE
fixing script to account for directories if they do not exist

### DIFF
--- a/mdct-setup.sh
+++ b/mdct-setup.sh
@@ -1,7 +1,7 @@
 set -e
 
 # Script version
-SCRIPT_VERSION="1.0.2"
+SCRIPT_VERSION="1.0.3"
 
 # Define the clone directory and version file
 clone_dir="$HOME/Projects"
@@ -396,8 +396,10 @@ for url in "${repo_urls[@]}"; do
     fi
 
     # Run yarn in /services/ui-src/ directory
-    echo "Running yarn in /services/ui-src/ directory..."
-    (cd services/ui-src/ && yarn)
+    if [ -d "services/ui-src/node_modules" ]; then
+      echo "Running yarn in /services/ui-src/ directory..."
+      (cd services/ui-src/ && yarn)
+    fi
 
     # Check if app-api node_modules directory exists
     if [ -d "services/app-api/node_modules" ]; then
@@ -406,8 +408,10 @@ for url in "${repo_urls[@]}"; do
     fi
 
     # Run yarn in /services/app-api/ directory
-    echo "Running yarn in /services/app-api/ directory..."
-    (cd services/app-api/ && yarn)
+    if [ -d "services/app-api/node_modules" ]; then
+      echo "Running yarn in /services/app-api/ directory..."
+      (cd services/app-api/ && yarn)
+    fi
 
     # Check if database node_modules directory exists
     if [ -d "services/database/node_modules" ]; then
@@ -416,8 +420,10 @@ for url in "${repo_urls[@]}"; do
     fi
 
     # Run yarn in /services/app-api/ directory
-    echo "Running yarn in /services/database/ directory..."
-    (cd services/database/ && yarn)
+    if [ -d "services/database/node_modules" ]; then
+      echo "Running yarn in /services/database/ directory..."
+      (cd services/database/ && yarn)
+    fi
 
     # Check if ui node_modules directory exists
     if [ -d "services/ui/node_modules" ]; then
@@ -426,8 +432,10 @@ for url in "${repo_urls[@]}"; do
     fi
 
     # Run yarn in /services/app-api/ directory
-    echo "Running yarn in /services/ui/ directory..."
-    (cd services/ui/ && yarn)
+    if [ -d "services/ui/node_modules" ]; then
+      echo "Running yarn in /services/ui/ directory..."
+      (cd services/ui/ && yarn)
+    fi
 
     # Check if ui-auth node_modules directory exists
     if [ -d "services/ui-auth/node_modules" ]; then
@@ -436,8 +444,10 @@ for url in "${repo_urls[@]}"; do
     fi
 
     # Run yarn in /services/app-api/ directory
-    echo "Running yarn in /services/ui-auth/ directory..."
-    (cd services/ui-auth/ && yarn)
+    if [ -d "services/ui-auth/node_modules" ]; then
+      echo "Running yarn in /services/ui-auth/ directory..."
+      (cd services/ui-auth/ && yarn)
+    fi
 
     # Check if uploads node_modules directory exists
     if [ -d "services/uploads/node_modules" ]; then
@@ -446,8 +456,10 @@ for url in "${repo_urls[@]}"; do
     fi
 
     # Run yarn in /services/app-api/ directory
-    echo "Running yarn in /services/uploads/ directory..."
-    (cd services/uploads/ && yarn)
+    if [ -d "services/uploads/node_modules" ]; then
+      echo "Running yarn in /services/uploads/ directory..."
+      (cd services/uploads/ && yarn)
+    fi
 
     # Check if tests/cypress node_modules directory exists
     if [ -d "tests/cypress/node_modules" ]; then


### PR DESCRIPTION
### Description
Currently the script loops through standard services and cleans up node modules in each directory. HCBS has some of the directories but doesnt have others such as database or app-api ... this was causing the script to fail. Now the script is updated to account for that scenario. If the directory exists it will cd into it and run yarn, before when it attempted to cd it would say the directory does not exist. 


### Related ticket(s)
n/a

---
### How to test
run workspace setup...it should work for hcbs now 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---
