### PR TITLE
Removing app test from workspace setup test

### DIFF
--- a/.github/workflows/workspace-setup.yml
+++ b/.github/workflows/workspace-setup.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           curl -o mdct-setup.sh https://raw.githubusercontent.com/Enterprise-CMCS/macpro-mdct-tools/main/mdct-setup.sh && chmod +x mdct-setup.sh && ./mdct-setup.sh
 
-      # This job flexes the 1Password capability for MCR after the projects have been setup by using a 1password service account
+      # This job flexes the 1Password capability for MFP after the projects have been setup by using a 1password service account
       - name: one password test
         run: |
           cd ~/Projects/macpro-mdct-mfp
@@ -33,15 +33,6 @@ jobs:
           nvm install
           export OP_SERVICE_ACCOUNT_TOKEN=${{ secrets.MDCT_OP_TOKEN }}
           ./run update-env
-
-      # spin up MCR locally on the runner and run ui tests
-      - name: run app and tests
-        run: |
-          cd ~/Projects/macpro-mdct-mfp
-          source /tmp/.profile
-          ./run local&
-          while ! curl -s http://localhost:3030 >/dev/null; do sleep 10; done
-          yarn run test:ci
 
   # Notify the tools channel on failure
   notify_on_failure:


### PR DESCRIPTION
### Description
This PR removes the app e2e testing functionality of workspace setup. The original intent of this was to run workspace setup, which clones the repos and installs all dependencies. Then it cd's into the app repo spins up the app on the github runner then runs tests. It worked fine for a while but we're getting errors when running and a failing test is not really a failure of the workspace setup job. It makes things more complicated and confusing than its worth. This just removes that and simplifies things 

### Related ticket(s)


---
### How to test
on merge to main this should kick off a test and we'll see :) 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---
