### PR TITLE
Fix failure when vscode settings missing, like in new repo

### DIFF
--- a/mdct-setup.sh
+++ b/mdct-setup.sh
@@ -329,7 +329,9 @@ for url in "${repo_urls[@]}"; do
         continue
     fi
 
-    cp .vscode/settings.json.template .vscode/settings.json
+    if [ -f ".vscode/settings.json.template" ]; then
+        cp .vscode/settings.json.template .vscode/settings.json
+    fi
 
     [ ! -f ".nvmrc" ] && continue
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Setup script fails on new PASRR repo because it doesn't yet have the vscode settings template

Script should not fail on missing file for non-critical step

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run the setup script and verify it succeeds


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code