### PR TITLE
Changed kion.yml to reflect SAML auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /reporting/output
 **/.yarn/*
 .vscode/settings.json
+**/.DS_Store

--- a/mdct-setup.sh
+++ b/mdct-setup.sh
@@ -282,11 +282,10 @@ if [ "$CI" != "true" ]; then
     cat <<EOL > $kion_config_file
 kion:
   url: https://cloudtamer.cms.gov
-  api_key: ""
-  username: $user_id
-  idms_id: "2"
-  saml_metadata_file: ""
-  saml_sp_issuer: ""
+  idms_id: 5
+  saml_metadata_file: https://idm.cms.gov/app/exk10wd8mvjHwLRKa298/sso/saml/metadata
+  saml_sp_issuer: https://cloudtamer.cms.gov/api/v1/saml/auth
+  disable_cache: true
 EOL
     echo "Kion configuration file created at $kion_config_file"
   else

--- a/test-file.txt
+++ b/test-file.txt
@@ -1,2 +1,0 @@
-wrong thing
-seriously


### PR DESCRIPTION
### Description
Per [CMDCT-6386](https://jiraent.cms.gov/browse/CMDCT-6386), update kion.yml in setup script to reflect requirement to use SAML because AD login will be deprecated Aug 1st, 2026


### Related ticket(s)
[CMDCT-6386](https://jiraent.cms.gov/browse/CMDCT-6386)

---
### How to test
1. Delete your current ~/.kion.yml
2. Run the mdct-setup.sh script 


### Notes
If you are a current MDCT team member and just want an updated kion.yml, please run this in your terminal:
```zsh
rm -f ~/.kion.yml && cat <<'EOF' > ~/.kion.yml
kion:
  url: https://cloudtamer.cms.gov
  idms_id: 5
  saml_metadata_file: https://idm.cms.gov/app/exk10wd8mvjHwLRKa298/sso/saml/metadata
  saml_sp_issuer: https://cloudtamer.cms.gov/api/v1/saml/auth
  disable_cache: true
EOF
```


---
### Pre-review checklist

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---
